### PR TITLE
Add authentication API endpoints

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\ApiToken;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+class AuthController extends Controller
+{
+    /**
+     * Register a new user account.
+     */
+    public function register(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'first_name' => ['required', 'string', 'max:255'],
+            'last_name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email'],
+            'mobile_number' => ['required', 'string', 'max:30', 'unique:users,mobile_number'],
+            'password' => ['required', 'string', 'min:8'],
+        ]);
+
+        $user = new User([
+            'first_name' => $validated['first_name'],
+            'last_name' => $validated['last_name'],
+            'email' => $validated['email'],
+            'mobile_number' => $validated['mobile_number'],
+            'password' => $validated['password'],
+        ]);
+        $user->name = trim($validated['first_name'].' '.$validated['last_name']);
+        $user->save();
+
+        $token = $this->createToken($user, 'registration');
+
+        return response()->json([
+            'user' => $user->only([
+                'id',
+                'first_name',
+                'last_name',
+                'email',
+                'mobile_number',
+                'created_at',
+                'updated_at',
+            ]),
+            'token' => $token,
+        ], 201);
+    }
+
+    /**
+     * Attempt to authenticate a user.
+     */
+    public function login(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'username' => ['required', 'string'],
+            'password' => ['required', 'string'],
+        ]);
+
+        $user = User::query()
+            ->where('email', $validated['username'])
+            ->orWhere('mobile_number', $validated['username'])
+            ->first();
+
+        if (! $user || ! Hash::check($validated['password'], $user->password)) {
+            return response()->json([
+                'message' => __('auth.failed'),
+            ], 422);
+        }
+
+        $token = $this->createToken($user, 'login');
+
+        return response()->json([
+            'user' => $user->only([
+                'id',
+                'first_name',
+                'last_name',
+                'email',
+                'mobile_number',
+                'created_at',
+                'updated_at',
+            ]),
+            'token' => $token,
+        ]);
+    }
+
+    /**
+     * Invalidate the current API token.
+     */
+    public function logout(Request $request): JsonResponse
+    {
+        /** @var \App\Models\User $user */
+        $user = $request->user();
+        /** @var \App\Models\ApiToken|null $token */
+        $token = $request->attributes->get('apiToken');
+
+        if ($token instanceof ApiToken) {
+            $token->delete();
+        }
+
+        return response()->json([
+            'message' => 'Logged out successfully.',
+        ]);
+    }
+
+    /**
+     * Retrieve the authenticated user's profile.
+     */
+    public function me(Request $request): JsonResponse
+    {
+        /** @var \App\Models\User|null $user */
+        $user = $request->user();
+
+        if (! $user) {
+            return response()->json([
+                'message' => 'Unauthenticated.',
+            ], 401);
+        }
+
+        return response()->json([
+            'user' => $user->only([
+                'id',
+                'first_name',
+                'last_name',
+                'email',
+                'mobile_number',
+                'created_at',
+                'updated_at',
+            ]),
+        ]);
+    }
+
+    /**
+     * Create a new API token for the user.
+     */
+    protected function createToken(User $user, string $name): string
+    {
+        $user->apiTokens()->where('expires_at', '<', now())->delete();
+
+        $plainTextToken = Str::random(60);
+
+        $user->apiTokens()->create([
+            'name' => $name,
+            'token' => hash('sha256', $plainTextToken),
+            'last_used_at' => now(),
+            'expires_at' => now()->addDays(30),
+        ]);
+
+        return $plainTextToken;
+    }
+}

--- a/app/Http/Middleware/AuthenticateWithApiToken.php
+++ b/app/Http/Middleware/AuthenticateWithApiToken.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\ApiToken;
+use Closure;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AuthenticateWithApiToken
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $plainToken = $request->bearerToken();
+
+        if (! $plainToken) {
+            return $this->unauthorizedResponse();
+        }
+
+        $hashedToken = hash('sha256', $plainToken);
+
+        $apiToken = ApiToken::query()
+            ->with('user')
+            ->where('token', $hashedToken)
+            ->first();
+
+        if (! $apiToken || ($apiToken->expires_at && $apiToken->expires_at->isPast())) {
+            return $this->unauthorizedResponse();
+        }
+
+        $apiToken->forceFill(['last_used_at' => now()])->save();
+
+        /** @var Authenticatable|null $user */
+        $user = $apiToken->user;
+
+        if (! $user) {
+            return $this->unauthorizedResponse();
+        }
+
+        $request->setUserResolver(static fn (): ?Authenticatable => $user);
+        $request->attributes->set('apiToken', $apiToken);
+
+        return $next($request);
+    }
+
+    protected function unauthorizedResponse(): JsonResponse
+    {
+        return response()->json([
+            'message' => 'Unauthenticated.',
+        ], 401);
+    }
+}

--- a/app/Models/ApiToken.php
+++ b/app/Models/ApiToken.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ApiToken extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'user_id',
+        'name',
+        'token',
+        'expires_at',
+        'last_used_at',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var list<string>
+     */
+    protected $hidden = [
+        'token',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'expires_at' => 'datetime',
+            'last_used_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * Get the user that the token belongs to.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,7 +3,9 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Models\ApiToken;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -19,7 +21,10 @@ class User extends Authenticatable
      */
     protected $fillable = [
         'name',
+        'first_name',
+        'last_name',
         'email',
+        'mobile_number',
         'password',
     ];
 
@@ -44,5 +49,13 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    /**
+     * Get the API tokens that belong to the user.
+     */
+    public function apiTokens(): HasMany
+    {
+        return $this->hasMany(ApiToken::class);
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,17 +1,31 @@
 <?php
 
+use App\Http\Middleware\AuthenticateWithApiToken;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Routing\Middleware\ThrottleRequests;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
+        apiPrefix: 'api',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->group('api', [
+            HandlePrecognitiveRequests::class,
+            ThrottleRequests::class.':api',
+            SubstituteBindings::class,
+        ]);
+
+        $middleware->alias([
+            'auth.api' => AuthenticateWithApiToken::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -23,9 +23,15 @@ class UserFactory extends Factory
      */
     public function definition(): array
     {
+        $firstName = fake()->firstName();
+        $lastName = fake()->lastName();
+
         return [
-            'name' => fake()->name(),
+            'name' => trim($firstName.' '.$lastName),
+            'first_name' => $firstName,
+            'last_name' => $lastName,
             'email' => fake()->unique()->safeEmail(),
+            'mobile_number' => fake()->unique()->numerify('+7##########'),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),

--- a/database/migrations/2024_01_01_100000_add_profile_fields_to_users_table.php
+++ b/database/migrations/2024_01_01_100000_add_profile_fields_to_users_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('first_name')->after('id');
+            $table->string('last_name')->after('first_name');
+            $table->string('mobile_number')->unique()->after('email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['first_name', 'last_name', 'mobile_number']);
+        });
+    }
+};

--- a/database/migrations/2024_01_01_110000_create_api_tokens_table.php
+++ b/database/migrations/2024_01_01_110000_create_api_tokens_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('api_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('name')->nullable();
+            $table->string('token', 64)->unique();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('api_tokens');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,14 @@
+<?php
+
+use App\Http\Controllers\Api\AuthController;
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('auth')->group(function (): void {
+    Route::post('register', [AuthController::class, 'register']);
+    Route::post('login', [AuthController::class, 'login']);
+
+    Route::middleware('auth.api')->group(function (): void {
+        Route::post('logout', [AuthController::class, 'logout']);
+        Route::get('me', [AuthController::class, 'me']);
+    });
+});


### PR DESCRIPTION
## Summary
- configure the application to serve API routes with a custom token middleware
- add registration, login, logout, and profile endpoints that return bearer tokens
- persist issued tokens and extend the user schema with profile details needed by the client

## Testing
- composer install *(fails: GitHub downloads blocked by proxy CONNECT 403/timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68d443875b308324a89c31bd9c0b7e54