### PR TITLE
Define API rate limiter to avoid MissingRateLimiterException

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +22,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        RateLimiter::for('api', function (Request $request) {
+            return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
+        });
     }
 }


### PR DESCRIPTION
## Summary
- register the default `api` rate limiter to prevent MissingRateLimiterException

## Testing
- `php artisan test` *(fails: missing vendor dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e237cc840c83248c617088ea41fc1a